### PR TITLE
Fix walk_hugetlb_range() info leak

### DIFF
--- a/mm/pagewalk.c
+++ b/mm/pagewalk.c
@@ -142,8 +142,12 @@ static int walk_hugetlb_range(unsigned long addr, unsigned long end,
 	do {
 		next = hugetlb_entry_end(h, addr, end);
 		pte = huge_pte_offset(walk->mm, addr & hmask);
-		if (pte && walk->hugetlb_entry)
+		
+		if (pte)
 			err = walk->hugetlb_entry(pte, hmask, addr, next, walk);
+		else if (walk->pte_hole)
+			err = walk->pte_hole(addr, next, walk);
+		
 		if (err)
 			break;
 	} while (addr = next, addr != end);


### PR DESCRIPTION
Hi Development Team,

I noticed that the `mm/pagewalk.c` implementation in this project is based on an older Linux kernel version that predates the fix for [CVE-2017-16994](https://nvd.nist.gov/vuln/detail/CVE-2017-16994). 

The vulnerability arises because `walk_hugetlb_range()` did not correctly handle holes in hugetlb ranges. When used by
`mincore()` and similar users, this could lead to uninitialized kernel memory being copied to userspace, resulting in an information leak. 

What this PR does:
- Calling `walk->hugetlb_entry()` only when a huge PTE is present.
- Reporting holes in hugetlb ranges via the `walk->pte_hole` callback when it is provided.

Please review at your convenience. Thank you!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libos-nuse/net-next-nuse/61)
<!-- Reviewable:end -->
