### PR TITLE
Validate size before allocating xt_table_info

### DIFF
--- a/net/netfilter/x_tables.c
+++ b/net/netfilter/x_tables.c
@@ -659,6 +659,9 @@ struct xt_table_info *xt_alloc_table_info(unsigned int size)
 	struct xt_table_info *info = NULL;
 	size_t sz = sizeof(*info) + size;
 
+	if (sz < sizeof(*info))
+		return NULL;
+
 	/* Pedantry: prevent them from hitting BUG() in vmalloc.c --RR */
 	if ((SMP_ALIGN(size) >> PAGE_SHIFT) + 2 > totalram_pages)
 		return NULL;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in xt_alloc_table_info that was cloned from https://github.com/torvalds/linux but did not receive the security patch.

###Details:
Affected Function: xt_alloc_table_info in x_tables.c 
Original Fix: [original commit](https://github.com/torvalds/linux/commit/d157bd761585605b7882935ffb86286919f62ea1)


###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.
###References:
[original commit](https://github.com/torvalds/linux/commit/d157bd761585605b7882935ffb86286919f62ea1)
[link to original CVE/bug id](https://nvd.nist.gov/vuln/detail/cve-2016-3135)
Please review and merge this PR to ensure your repository is protected against this potential vulnerability

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libos-nuse/net-next-nuse/68)
<!-- Reviewable:end -->
